### PR TITLE
Change target version of Elasticsearch to 1.0.0.RC1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <version>7</version>
     </parent>
 	<properties>
-		<elasticsearch.version>0.90.5</elasticsearch.version>
+		<elasticsearch.version>1.0.0.RC1</elasticsearch.version>
 	</properties>
 	<build>
 		<plugins>

--- a/src/main/java/org/codelibs/elasticsearch/quartz/QuartzSchedulerException.java
+++ b/src/main/java/org/codelibs/elasticsearch/quartz/QuartzSchedulerException.java
@@ -1,9 +1,9 @@
 package org.codelibs.elasticsearch.quartz;
 
-import org.elasticsearch.ElasticSearchException;
+import org.elasticsearch.ElasticsearchException;
 import org.quartz.SchedulerException;
 
-public class QuartzSchedulerException extends ElasticSearchException {
+public class QuartzSchedulerException extends ElasticsearchException {
 
     private static final long serialVersionUID = 1L;
 


### PR DESCRIPTION
Change the version of elasticsearch to 1.0.0.RC1
No change the version of plugin.
Please change a suitable version plugin
